### PR TITLE
[hass-livoltek] Handle null API responses in config flow and diagnostics

### DIFF
--- a/custom_components/livoltek/config_flow.py
+++ b/custom_components/livoltek/config_flow.py
@@ -82,15 +82,21 @@ class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
         api_client.set_default_header("Authorization", access_token)
         api = DefaultApi(api_client)
 
-        thread = api.list_sites(
+        thread = api.hess_api_user_sites_list_get_with_http_info(
             user_token, size=10, page=1, async_req=True, _preload_content=True
         )
         user_sites = thread.get()
 
-        if user_sites is None or user_sites.data is None:
+        if not user_sites:
+            LOGGER.warning("Livoltek API returned empty response for sites list")
             return []
 
-        return user_sites.data.list or []
+        first_result = user_sites[0]
+        if first_result is None or first_result.data is None:
+            LOGGER.warning("Livoltek API returned empty site data")
+            return []
+
+        return first_result.data.list or []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/livoltek/config_flow.py
+++ b/custom_components/livoltek/config_flow.py
@@ -59,6 +59,7 @@ async def validate_input(secuid: str, api_key: str, emea: bool) -> str:
 
     return token
 
+
 class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for Livoltek."""
 
@@ -81,11 +82,15 @@ class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
         api_client.set_default_header("Authorization", access_token)
         api = DefaultApi(api_client)
 
-        thread = api.hess_api_user_sites_list_get_with_http_info(
+        thread = api.list_sites(
             user_token, size=10, page=1, async_req=True, _preload_content=True
         )
         user_sites = thread.get()
-        return user_sites[0].data.list
+
+        if user_sites is None or user_sites.data is None:
+            return []
+
+        return user_sites.data.list or []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/livoltek/diagnostics.py
+++ b/custom_components/livoltek/diagnostics.py
@@ -16,6 +16,13 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: LivoltekDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-    # Round-trip via JSON to trigger serialization
-    data: dict[str, Any] = json.loads(coordinator.data.json())
+
+    if coordinator.data is None:
+        return {}
+
+    try:
+        data: dict[str, Any] = json.loads(coordinator.data.json())
+    except AttributeError:
+        return {}
+
     return data

--- a/custom_components/livoltek/diagnostics.py
+++ b/custom_components/livoltek/diagnostics.py
@@ -22,7 +22,7 @@ async def async_get_config_entry_diagnostics(
 
     try:
         data: dict[str, Any] = json.loads(coordinator.data.json())
-    except AttributeError:
+    except (AttributeError, json.JSONDecodeError):
         return {}
 
     return data


### PR DESCRIPTION
## Summary

This PR makes the integration more defensive when the Livoltek API returns null or incomplete payloads.

## Changes

- guard against `None` in config flow site selection
- guard diagnostics generation when coordinator data is unavailable

## Why

Several users in #100 reported intermittent null responses from the Livoltek API.
This PR focuses on preventing crashes and keeping the change minimal.

## Notes

This PR does not yet add a Battery SoC fallback from `/ESS`.
That can be handled separately in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience when fetching site information: the system now safely handles missing or malformed site responses and avoids crashes, returning an empty result when necessary.
  * Enhanced diagnostics error handling: reporting gracefully returns empty diagnostics when runtime data is absent or cannot be serialised, preventing failures during diagnostics collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->