### PR TITLE
Set API request timeout to 20 seconds

### DIFF
--- a/custom_components/livoltek/config_flow.py
+++ b/custom_components/livoltek/config_flow.py
@@ -29,6 +29,7 @@ from homeassistant.exceptions import (
 )
 
 from .const import (
+    API_REQUEST_TIMEOUT,
     CONF_SECUID_ID,
     CONF_EMEA_ID,
     CONF_SITE_ID,
@@ -87,7 +88,11 @@ class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
         user_sites = await loop.run_in_executor(
             None,
             lambda: api.list_sites(
-                user_token, size=10, page=1, _preload_content=True
+                user_token,
+                size=10,
+                page=1,
+                _preload_content=True,
+                _request_timeout=API_REQUEST_TIMEOUT,
             ),
         )
         if not user_sites:

--- a/custom_components/livoltek/const.py
+++ b/custom_components/livoltek/const.py
@@ -23,6 +23,7 @@ CONF_SITE_ID = "site_id"
 DATA_ACCESS_TOKEN = "access_token"
 
 DEFAULT_NAME = "Livoltek"
+API_REQUEST_TIMEOUT = 20
 
 LIVOLTEK_EMEA_SERVER = "https://api-eu.livoltek-portal.com:8081"
 LIVOLTEK_GLOBAL_SERVER = "https://api.livoltek-portal.com:8081"

--- a/custom_components/livoltek/helper.py
+++ b/custom_components/livoltek/helper.py
@@ -25,6 +25,7 @@ from pylivoltek.models import (
 from pylivoltek.rest import ApiException
 
 from .const import (
+    API_REQUEST_TIMEOUT,
     CONF_EMEA_ID,
     CONF_SECUID_ID,
     CONF_SITE_ID,
@@ -62,7 +63,11 @@ async def async_get_login_token(host: str, api_key: str, secuid: str) -> str:
     loop = asyncio.get_running_loop()
     thread_result = await loop.run_in_executor(
         None,
-        lambda: api.hess_api_login_post_with_http_info(model, _preload_content=True),
+        lambda: api.hess_api_login_post_with_http_info(
+            model,
+            _preload_content=True,
+            _request_timeout=API_REQUEST_TIMEOUT,
+        ),
     )
     response = thread_result[0]
 
@@ -116,7 +121,9 @@ async def async_get_site(
     site = await loop.run_in_executor(
         None,
         lambda: api.hess_api_site_site_id_overview_get_with_http_info(
-            user_token, site_id
+            user_token,
+            site_id,
+            _request_timeout=API_REQUEST_TIMEOUT,
         ),
     )
     return site[0].data
@@ -131,7 +138,9 @@ async def async_get_cur_power_flow(
         current_power_flow = await loop.run_in_executor(
             None,
             lambda: api.hess_api_site_site_id_cur_powerflow_get_with_http_info(
-                user_token, site_id
+                user_token,
+                site_id,
+                _request_timeout=API_REQUEST_TIMEOUT,
             ),
         )
         return current_power_flow[0].data
@@ -148,7 +157,11 @@ async def async_get_device_list(
     device_list = await loop.run_in_executor(
         None,
         lambda: api.hess_api_device_site_id_list_get_with_http_info(
-            user_token, site_id, 1, 10
+            user_token,
+            site_id,
+            1,
+            10,
+            _request_timeout=API_REQUEST_TIMEOUT,
         ),
     )
     return device_list[0].data["list"]
@@ -163,7 +176,9 @@ async def async_get_device_generation(
     device_generation = await loop.run_in_executor(
         None,
         lambda: api.hess_api_device_device_id_real_electricity_get_with_http_info(
-            user_token, device_id
+            user_token,
+            device_id,
+            _request_timeout=API_REQUEST_TIMEOUT,
         ),
     )
     return device_generation[0].data
@@ -178,7 +193,9 @@ async def async_get_recent_grid(
     recent_grid = await loop.run_in_executor(
         None,
         lambda: api.get_recent_energy_import_export_with_http_info(
-            user_token, site_id
+            user_token,
+            site_id,
+            _request_timeout=API_REQUEST_TIMEOUT,
         ),
     )
     return recent_grid[0]["data"]
@@ -193,7 +210,9 @@ async def async_get_recent_solar(
     recent_solar = await loop.run_in_executor(
         None,
         lambda: api.get_recent_solar_generated_energy_with_http_info(
-            user_token, site_id
+            user_token,
+            site_id,
+            _request_timeout=API_REQUEST_TIMEOUT,
         ),
     )
     return recent_solar[0]["data"]
@@ -206,7 +225,7 @@ async def async_update_devices(entry: ConfigEntry, hass: HomeAssistant) -> None:
     user_token = str(entry.data[CONF_USERTOKEN_ID])
     site_id = str(entry.data[CONF_SITE_ID])
 
-    async with asyncio.timeout(10):
+    async with asyncio.timeout(API_REQUEST_TIMEOUT):
         device_list = await async_get_device_list(api, user_token, site_id)
 
     await async_register_devices(api, entry, user_token, site_id, device_list, hass)
@@ -225,13 +244,14 @@ async def async_register_devices(
 
     for device in device_list:
         inverter_sn = device["inverterSn"]
-        async with asyncio.timeout(10):
+        async with asyncio.timeout(API_REQUEST_TIMEOUT):
             dev = await hass.async_add_executor_job(
                 lambda sn=inverter_sn: api.get_device_details(
                     user_token,
                     site_id,
                     sn,
                     _preload_content=True,
+                    _request_timeout=API_REQUEST_TIMEOUT,
                 ).data
             )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the Livoltek config flow."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from pylivoltek.api import DefaultApi
 
 from custom_components.livoltek.config_flow import LivoltekFlowHandler
 from custom_components.livoltek.const import (
+    API_REQUEST_TIMEOUT,
     CONF_EMEA_ID,
     CONF_SECUID_ID,
     CONF_SITE_ID,
@@ -102,6 +104,48 @@ def test_get_site_list_returns_selector_options() -> None:
         {"value": "site-1", "label": "House"},
         {"value": "site-2", "label": "Garage"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_sites_sets_request_timeout(monkeypatch) -> None:
+    """Site listing should use the integration HTTP timeout."""
+
+    class FakeApiClient:
+        def __init__(self, config) -> None:
+            self.config = config
+            self.headers = {}
+
+        def set_default_header(self, name: str, value: str) -> None:
+            self.headers[name] = value
+
+    class FakeDefaultApi:
+        def __init__(self, api_client) -> None:
+            self.api_client = api_client
+
+        def list_sites(self, user_token, **kwargs):
+            assert user_token == "user-token"
+            assert kwargs["_preload_content"] is True
+            assert kwargs["_request_timeout"] == API_REQUEST_TIMEOUT
+            return [
+                SimpleNamespace(
+                    data=SimpleNamespace(
+                        list=[
+                            {
+                                "powerStationId": "site-123",
+                                "powerStationName": "Home",
+                            }
+                        ]
+                    )
+                )
+            ]
+
+    monkeypatch.setattr("custom_components.livoltek.config_flow.ApiClient", FakeApiClient)
+    monkeypatch.setattr("custom_components.livoltek.config_flow.DefaultApi", FakeDefaultApi)
+
+    flow = LivoltekFlowHandler()
+    sites = await flow.get_sites("https://example.com", "access-token", "user-token")
+
+    assert sites == [{"powerStationId": "site-123", "powerStationName": "Home"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -18,7 +18,7 @@ from custom_components.livoltek.const import (
     LIVOLTEK_GLOBAL_SERVER,
 )
 
-from .common import build_device_details, make_thread
+from .common import build_device_details
 
 
 def test_validate_jwt_returns_true_for_decodable_token(monkeypatch) -> None:
@@ -116,6 +116,35 @@ async def test_async_get_api_client_refreshes_invalid_token_on_emea(
 
 
 @pytest.mark.asyncio
+async def test_async_get_login_token_sets_request_timeout(monkeypatch) -> None:
+    """Login requests should use the integration HTTP timeout."""
+
+    class FakeApiClient:
+        def __init__(self, config) -> None:
+            self.config = config
+
+    class FakeDefaultApi:
+        def __init__(self, api_client) -> None:
+            self.api_client = api_client
+
+        def hess_api_login_post_with_http_info(self, model, **kwargs):
+            assert kwargs["_preload_content"] is True
+            assert kwargs["_request_timeout"] == helper.API_REQUEST_TIMEOUT
+            return (SimpleNamespace(message="SUCCESS", data={"data": "token"}),)
+
+    monkeypatch.setattr(helper, "ApiClient", FakeApiClient)
+    monkeypatch.setattr(helper, "DefaultApi", FakeDefaultApi)
+
+    token = await helper.async_get_login_token(
+        LIVOLTEK_GLOBAL_SERVER,
+        "api-key",
+        "secuid-123",
+    )
+
+    assert token == "token"
+
+
+@pytest.mark.asyncio
 async def test_async_update_devices_unpacks_api_result_before_fetching_list(
     livoltek_entry,
     monkeypatch,
@@ -151,9 +180,11 @@ async def test_async_register_devices_creates_device_registry_entries(
 
     api = Mock()
     api.get_device_details.side_effect = [
-        make_thread(SimpleNamespace(data=build_device_details(id="device-1"))),
-        make_thread(SimpleNamespace(data=build_device_details(id="device-2"))),
+        SimpleNamespace(data=build_device_details(id="device-1")),
+        SimpleNamespace(data=build_device_details(id="device-2")),
     ]
+    hass = Mock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda job: job())
 
     await helper.async_register_devices(
         api=api,
@@ -161,13 +192,16 @@ async def test_async_register_devices_creates_device_registry_entries(
         user_token="user-token-123",
         site_id="site-123",
         device_list=[{"inverterSn": "INV-001"}, {"inverterSn": "INV-002"}],
-        hass=object(),
+        hass=hass,
     )
 
     assert registry.async_get_or_create.call_count == 2
     first_call = registry.async_get_or_create.call_args_list[0]
     assert first_call.kwargs["config_entry_id"] == livoltek_entry.entry_id
     assert first_call.kwargs["identifiers"] == {("livoltek", "device-1")}
+    assert api.get_device_details.call_args_list[0].kwargs["_request_timeout"] == (
+        helper.API_REQUEST_TIMEOUT
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Standardize the timeout for all Livoltek API calls to 20 seconds to improve reliability when handling slow portal responses. This replaces hardcoded 10-second timeouts and ensures the timeout parameter is correctly passed across all helper functions and the config flow.
