### PR TITLE
Refactor API site listing method in config_flow.py

### DIFF
--- a/custom_components/livoltek/config_flow.py
+++ b/custom_components/livoltek/config_flow.py
@@ -87,10 +87,10 @@ class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
         loop = asyncio.get_running_loop()
         user_sites = await loop.run_in_executor(
             None,
-            lambda: api.list_sites(
+            lambda: api.hess_api_user_sites_list_get(
                 user_token,
-                size=10,
-                page=1,
+                1,
+                10,
                 _preload_content=True,
                 _request_timeout=API_REQUEST_TIMEOUT,
             ),
@@ -98,23 +98,11 @@ class LivoltekFlowHandler(ConfigFlow, domain=DOMAIN):
         if not user_sites:
             LOGGER.warning("Livoltek API returned empty response for sites list")
             return []
-        first_result = user_sites[0]
-        if first_result is None or first_result.data is None:
+        if user_sites.data is None:
             LOGGER.warning("Livoltek API returned empty site data")
             return []
 
-        return first_result.data.list or []
-
-        if not user_sites:
-            LOGGER.warning("Livoltek API returned empty response for sites list")
-            return []
-
-        first_result = user_sites[0]
-        if first_result is None or first_result.data is None:
-            LOGGER.warning("Livoltek API returned empty site data")
-            return []
-
-        return first_result.data.list or []
+        return user_sites.data.list or []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
Fix for latest Homeassitant version. i coud not login.
was getting this error
Logger: aiohttp.server
Source: /usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py:488
First occurred: 15:20:51 (1 occurrence)
Last logged: 15:20:51

Error handling request from 172.30.33.1
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py", line 517, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_app.py", line 569, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 92, in security_filter_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 214, in forwarded_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 26, in request_context_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 90, in ban_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 295, in auth_middleware
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/headers.py", line 41, in headers_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/http.py", line 89, in handle
    result = await handler(request, **request.match_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/decorators.py", line 83, in with_admin
    return await func(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/config/config_entries.py", line 234, in post
    return await super().post(request, flow_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/http/data_validator.py", line 74, in wrapper
    return await method(view, request, data, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/data_entry_flow.py", line 121, in post
    result = await self._flow_mgr.async_configure(flow_id, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 336, in async_configure
    result = await self._async_configure(flow_id, user_input)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 1536, in _async_configure
    return await super()._async_configure(flow_id, user_input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 383, in _async_configure
    result = await self._async_handle_step(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        flow, cur_step["step_id"], user_input
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 483, in _async_handle_step
    result: _FlowResultT = await getattr(flow, method)(user_input)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/livoltek/config_flow.py", line 141, in async_step_user
    return await self.async_step_select_site()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/livoltek/config_flow.py", line 198, in async_step_select_site
    sites = await self.get_sites(
            ^^^^^^^^^^^^^^^^^^^^^
        host, self.access_token, self.data[CONF_USERTOKEN_ID]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/config/custom_components/livoltek/config_flow.py", line 88, in get_sites
    user_sites = await loop.run_in_executor(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<8 lines>...
    )
    ^
  File "/usr/local/lib/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/usr/local/lib/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/config/custom_components/livoltek/config_flow.py", line 90, in <lambda>
    lambda: api.list_sites(
            ^^^^^^^^^^^^^^
AttributeError: 'DefaultApi' object has no attribute 'list_sites'
after the modifications is working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated site data retrieval to enhance backend service compatibility
  * Streamlined site response handling for improved data processing efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->