### PR TITLE
[hass-livoltek] Restore Battery SoC using direct /ESS fallback

### DIFF
--- a/custom_components/livoltek/coordinator.py
+++ b/custom_components/livoltek/coordinator.py
@@ -78,11 +78,15 @@ class LivoltekDataUpdateCoordinator(DataUpdateCoordinator):
             api,
             self.config_entry.data[CONF_USERTOKEN_ID],
             self.config_entry.data[CONF_SITE_ID],
-            self.access_token,
         )
 
         if energy_storage is None:
+            LOGGER.debug(
+                "Wrapper /ESS returned no data; falling back to direct /ESS fetch for site %s",
+                self.config_entry.data[CONF_SITE_ID],
+            )
             energy_storage = await async_get_energy_storage_direct(
+                self.hass,
                 api.api_client.configuration.host,
                 self.config_entry.data[CONF_USERTOKEN_ID],
                 self.config_entry.data[CONF_SITE_ID],

--- a/custom_components/livoltek/coordinator.py
+++ b/custom_components/livoltek/coordinator.py
@@ -22,6 +22,7 @@ from .helper import (
     async_get_cur_power_flow,
     async_get_device_list,
     async_get_energy_storage,
+    async_get_energy_storage_direct,
     async_get_recent_grid,
     async_get_recent_solar,
 )
@@ -77,7 +78,16 @@ class LivoltekDataUpdateCoordinator(DataUpdateCoordinator):
             api,
             self.config_entry.data[CONF_USERTOKEN_ID],
             self.config_entry.data[CONF_SITE_ID],
+            self.access_token,
         )
+
+        if energy_storage is None:
+            energy_storage = await async_get_energy_storage_direct(
+                api.api_client.configuration.host,
+                self.config_entry.data[CONF_USERTOKEN_ID],
+                self.config_entry.data[CONF_SITE_ID],
+                self.access_token,
+            )
 
         recent_grid = await async_get_recent_grid(
             api,
@@ -106,3 +116,4 @@ class LivoltekDataUpdateCoordinator(DataUpdateCoordinator):
         self.current_power_flow = current_power_flow
         self.energy_storage = energy_storage
         LOGGER.debug("Current Power Flow: %s", current_power_flow)
+        LOGGER.debug("Energy Storage (/ESS): %s", energy_storage)

--- a/custom_components/livoltek/helper.py
+++ b/custom_components/livoltek/helper.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import Any
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+
+import aiohttp
 
 from homeassistant.auth.jwt_wrapper import PyJWT
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -172,7 +172,7 @@ async def async_get_device_list(
 
 
 async def async_get_energy_storage(
-    api: DefaultApi, user_token: str, site_id: str, auth_token: str
+    api: DefaultApi, user_token: str, site_id: str
 ) -> EnergyStore | None:
     """Get energy storage information from the /ESS endpoint."""
     try:
@@ -195,6 +195,8 @@ async def async_get_energy_storage(
             "Failed to fetch energy storage data for site %s: %s", site_id, e
         )
         return None
+    except asyncio.CancelledError:
+        raise
     except Exception as e:
         LOGGER.warning(
             "Unexpected error fetching energy storage for site %s: %s", site_id, e
@@ -204,27 +206,29 @@ async def async_get_energy_storage(
 
 
 async def async_get_energy_storage_direct(
-    host: str, user_token: str, site_id: str, auth_token: str
+    hass, host: str, user_token: str, site_id: str, auth_token: str
 ) -> dict[str, Any] | None:
     """Fetch /ESS directly, bypassing pylivoltek wrapper issues."""
+    session = async_get_clientsession(hass)
+    url = f"{host.rstrip('/')}/hess/api/site/{site_id}/ESS"
+
     try:
-        url = f"{host}/hess/api/site/{site_id}/ESS?{urlencode({'userToken': user_token})}"
+        async with session.get(
+            url,
+            params={"userToken": user_token},
+            headers={
+                "Authorization": auth_token,
+                "Accept": "application/json",
+            },
+            timeout=aiohttp.ClientTimeout(total=API_REQUEST_TIMEOUT),
+        ) as resp:
+            resp.raise_for_status()
+            payload = await resp.json()
 
-        def _fetch() -> dict[str, Any] | None:
-            req = Request(
-                url,
-                headers={
-                    "Authorization": auth_token,
-                    "Accept": "application/json",
-                },
-            )
-            with urlopen(req, timeout=API_REQUEST_TIMEOUT) as resp:
-                payload = json.loads(resp.read().decode("utf-8"))
-            return payload.get("data")
-
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, _fetch)
-    except Exception as e:
+        return payload.get("data")
+    except asyncio.CancelledError:
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, TypeError) as e:
         LOGGER.warning(
             "Direct /ESS fetch failed for site %s: %s", site_id, e
         )

--- a/custom_components/livoltek/helper.py
+++ b/custom_components/livoltek/helper.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 from homeassistant.auth.jwt_wrapper import PyJWT
 from homeassistant.config_entries import ConfigEntry
@@ -169,7 +172,7 @@ async def async_get_device_list(
 
 
 async def async_get_energy_storage(
-    api: DefaultApi, user_token: str, site_id: str
+    api: DefaultApi, user_token: str, site_id: str, auth_token: str
 ) -> EnergyStore | None:
     """Get energy storage information from the /ESS endpoint."""
     try:
@@ -177,14 +180,54 @@ async def async_get_energy_storage(
         result = await loop.run_in_executor(
             None,
             lambda: api.get_energy_storage_with_http_info(
-                user_token,
                 site_id,
+                user_token,
                 _request_timeout=API_REQUEST_TIMEOUT,
             ),
         )
+
+        if not result or not result[0]:
+            return None
+
         return result[0].data
     except ApiException as e:
-        LOGGER.warning("Failed to fetch energy storage data for site %s: %s", site_id, e)
+        LOGGER.warning(
+            "Failed to fetch energy storage data for site %s: %s", site_id, e
+        )
+        return None
+    except Exception as e:
+        LOGGER.warning(
+            "Unexpected error fetching energy storage for site %s: %s", site_id, e
+        )
+        return None
+
+
+
+async def async_get_energy_storage_direct(
+    host: str, user_token: str, site_id: str, auth_token: str
+) -> dict[str, Any] | None:
+    """Fetch /ESS directly, bypassing pylivoltek wrapper issues."""
+    try:
+        url = f"{host}/hess/api/site/{site_id}/ESS?{urlencode({'userToken': user_token})}"
+
+        def _fetch() -> dict[str, Any] | None:
+            req = Request(
+                url,
+                headers={
+                    "Authorization": auth_token,
+                    "Accept": "application/json",
+                },
+            )
+            with urlopen(req, timeout=API_REQUEST_TIMEOUT) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            return payload.get("data")
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _fetch)
+    except Exception as e:
+        LOGGER.warning(
+            "Direct /ESS fetch failed for site %s: %s", site_id, e
+        )
         return None
 
 

--- a/custom_components/livoltek/sensor.py
+++ b/custom_components/livoltek/sensor.py
@@ -53,13 +53,25 @@ def _battery_soc(coordinator: Any) -> float | None:
     """Return battery SOC, preferring /ESS and falling back to curPowerflow."""
     ess = coordinator.energy_storage
 
+    def _as_float(value: Any) -> float | None:
+        if value in (None, ""):
+            return None
+        if isinstance(value, str) and value.lower() == "unknown":
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     if ess is not None:
         value = None
 
         if isinstance(ess, dict):
-            value = ess.get("current_soc", ess.get("currentSoc"))
+            value = ess.get("current_soc")
+            if _as_float(value) is None:
+                value = ess.get("currentSoc")
 
-            if value in (None, "", "unknown"):
+            if _as_float(value) is None:
                 history_map = ess.get("historyMap") or {}
                 if isinstance(history_map, dict):
                     latest_ts = None
@@ -86,20 +98,16 @@ def _battery_soc(coordinator: Any) -> float | None:
                     value = latest_soc
         else:
             value = getattr(ess, "current_soc", None)
-            if value is None:
+            if _as_float(value) is None:
                 value = getattr(ess, "currentSoc", None)
 
-        try:
-            return float(value) if value is not None else None
-        except (TypeError, ValueError):
-            return None
+        parsed_soc = _as_float(value)
+        if parsed_soc is not None:
+            return parsed_soc
 
     if coordinator.current_power_flow is not None:
         value = _get_pf(coordinator, "energy_soc", "energySoc")
-        try:
-            return float(value) if value is not None else None
-        except (TypeError, ValueError):
-            return None
+        return _as_float(value)
 
     return None
 

--- a/custom_components/livoltek/sensor.py
+++ b/custom_components/livoltek/sensor.py
@@ -50,12 +50,57 @@ def _get_pf(coordinator, attr: str, json_key: str):
     return getattr(pf, attr, None)
 
 def _battery_soc(coordinator: Any) -> float | None:
-    """Return battery SOC, preferring the /ESS endpoint over /curPowerflow."""
+    """Return battery SOC, preferring /ESS and falling back to curPowerflow."""
     ess = coordinator.energy_storage
-    if ess is not None and ess.current_soc is not None:
-        return ess.current_soc
+
+    if ess is not None:
+        value = None
+
+        if isinstance(ess, dict):
+            value = ess.get("current_soc", ess.get("currentSoc"))
+
+            if value in (None, "", "unknown"):
+                history_map = ess.get("historyMap") or {}
+                if isinstance(history_map, dict):
+                    latest_ts = None
+                    latest_soc = None
+                    for bucket_key, bucket_values in history_map.items():
+                        try:
+                            bucket_ts = int(bucket_key)
+                        except (TypeError, ValueError):
+                            bucket_ts = -1
+                        if not isinstance(bucket_values, list):
+                            continue
+                        for item in bucket_values:
+                            if not isinstance(item, dict):
+                                continue
+                            soc = item.get("energySoc")
+                            item_ts = item.get("time", bucket_ts)
+                            try:
+                                item_ts = int(item_ts)
+                            except (TypeError, ValueError):
+                                item_ts = bucket_ts
+                            if soc is not None and (latest_ts is None or item_ts >= latest_ts):
+                                latest_ts = item_ts
+                                latest_soc = soc
+                    value = latest_soc
+        else:
+            value = getattr(ess, "current_soc", None)
+            if value is None:
+                value = getattr(ess, "currentSoc", None)
+
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
     if coordinator.current_power_flow is not None:
-        return _get_pf(coordinator, "energy_soc", "energySoc")
+        value = _get_pf(coordinator, "energy_soc", "energySoc")
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
     return None
 
 SENSORS = [

--- a/custom_components/livoltek/sensor.py
+++ b/custom_components/livoltek/sensor.py
@@ -87,14 +87,17 @@ def _battery_soc(coordinator: Any) -> float | None:
                             if not isinstance(item, dict):
                                 continue
                             soc = item.get("energySoc")
+                            parsed_soc = _as_float(soc)
+                            if parsed_soc is None:
+                                continue
                             item_ts = item.get("time", bucket_ts)
                             try:
                                 item_ts = int(item_ts)
                             except (TypeError, ValueError):
                                 item_ts = bucket_ts
-                            if soc is not None and (latest_ts is None or item_ts >= latest_ts):
+                            if latest_ts is None or item_ts >= latest_ts:
                                 latest_ts = item_ts
-                                latest_soc = soc
+                                latest_soc = parsed_soc
                     value = latest_soc
         else:
             value = getattr(ess, "current_soc", None)


### PR DESCRIPTION
## Summary

Restore Battery SoC reporting when `curPowerflow.energySoc` is `null` by adding a direct `/ESS` fallback.

## What this changes

* keep the existing `/curPowerflow` path for current power sensors
* keep the existing wrapped `/ESS` path when it works
* add a direct `/ESS` fetch fallback when the wrapper path returns no usable data
* read `currentSoc` when present
* otherwise fall back to the latest `historyMap[*].energySoc`
* preserve `curPowerflow.energySoc` as the final fallback when `/ESS` has no usable numeric SOC

## Why

In my setup, the integration still retrieves PV / load / grid values correctly, but `curPowerflow.energySoc` often comes back as `null`, leaving Battery SoC as unknown.

The direct `/ESS` response still contains usable battery SoC data, so this restores Battery SoC without changing the existing power-flow sensor path.

## Validation

Tested locally in Home Assistant.

Before this change:

* Battery SoC remained unknown

After this change:

* Battery SoC reports correctly again
* in my setup it now shows the expected reserve-floor value

## Notes

This PR is intentionally kept small and focused on Battery SoC recovery only.

It is a clean replacement for my earlier larger PR, which became noisy after I rewrote my fork history while cleaning up commit email exposure.

Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved energy storage data retrieval with fallback mechanism for enhanced reliability.
  * Enhanced battery state-of-charge detection with support for multiple data formats.
  * Expanded error handling to capture and manage additional failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->